### PR TITLE
20240906 カレンダーのプログラム(JavaScript)

### DIFF
--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+
+import { Command } from "commander";
+import { DateTime } from "luxon";
+
+const program = new Command();
+
+program
+  .option("-y, --year <year>", "年を指定", parseInt)
+  .option("-m, --month <month>", "月を指定", parseInt)
+  .parse(process.argv);
+
+const options = program.opts();
+
+function printCalendar(year, month) {
+  if (
+    !year ||
+    !month ||
+    year < 1900 ||
+    year > 2100 ||
+    month < 1 ||
+    month > 12
+  ) {
+    process.stderr.write(
+      "指定された年または月が無効です。(年:1900〜2100,月:1〜12が有効)\n",
+    );
+    return;
+  }
+
+  const firstDay = DateTime.local(year, month, 1);
+  const lastDay = firstDay.endOf("month");
+
+  process.stdout.write(firstDay.toFormat("M月 yyyy").padStart(13) + "\n");
+  process.stdout.write("日 月 火 水 木 金 土\n");
+
+  let padding = " ".repeat((firstDay.weekday % 7) * 3);
+  process.stdout.write(padding);
+
+  for (let day = firstDay; day <= lastDay; day = day.plus({ days: 1 })) {
+    process.stdout.write(day.day.toString().padStart(2) + " ");
+    if (day.weekday === 6) {
+      process.stdout.write("\n");
+    }
+  }
+
+  if (lastDay.weekday !== 6) {
+    process.stdout.write("\n");
+  }
+}
+
+function main() {
+  const year = options.year || DateTime.now().year;
+  const month = options.month || DateTime.now().month;
+
+  try {
+    printCalendar(year, month);
+  } catch (error) {
+    process.stderr.write(
+      "無効な日付が指定されました。詳細: " + error.message + "\n",
+    );
+  }
+}
+
+main();

--- a/02.calendar/package-lock.json
+++ b/02.calendar/package-lock.json
@@ -4,6 +4,10 @@
   "requires": true,
   "packages": {
     "": {
+      "dependencies": {
+        "commander": "^9.0.0",
+        "luxon": "^3.0.0"
+      },
       "devDependencies": {
         "@eslint/js": "^9.9.0",
         "eslint": "^9.9.0",
@@ -298,6 +302,15 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -785,6 +798,15 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/luxon": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.5.0.tgz",
+      "integrity": "sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/minimatch": {
       "version": "3.1.2",

--- a/02.calendar/package.json
+++ b/02.calendar/package.json
@@ -3,6 +3,10 @@
     "fix": "prettier --write . && eslint --fix .",
     "lint": "prettier --check . && eslint ."
   },
+  "dependencies": {
+    "commander": "^9.0.0",
+    "luxon": "^3.0.0"
+  },
   "devDependencies": {
     "@eslint/js": "^9.9.0",
     "eslint": "^9.9.0",


### PR DESCRIPTION
## プラクティス
[カレンダーのプログラム(JavaScript)](https://bootcamp.fjord.jp/practices/196)

## 使用ライブラリ
[Luxon(github)](https://github.com/moment/luxon)
[commander(github)](https://github.com/tj/commander.js)

## 既存のcalコマンド
```
chiroru@MacBook-Pro-3 02.calendar % cal
      9月 2024         
日 月 火 水 木 金 土  
 1  2  3  4  5  6  7  
 8  9 10 11 12 13 14  
15 16 17 18 19 20 21  
22 23 24 25 26 27 28  
29 30                
```

## 実装したプログラムの実行結果
```
chiroru@MacBook-Pro-3 02.calendar % ./cal.js                     
      9月 2024
日 月 火 水 木 金 土
 1  2  3  4  5  6  7 
 8  9 10 11 12 13 14 
15 16 17 18 19 20 21 
22 23 24 25 26 27 28 
29 30 
```

## オプション指定
オプションの有効値(年:1900〜2100,月:1〜12)
```
chiroru@MacBook-Pro-3 02.calendar % ./cal.js -y 2030 -m 12
     12月 2030
日 月 火 水 木 金 土
 1  2  3  4  5  6  7 
 8  9 10 11 12 13 14 
15 16 17 18 19 20 21 
22 23 24 25 26 27 28 
29 30 31 
```

## 無効なオプションが設定された場合
以下のようなエラーメッセージが出力されるように。
```
chiroru@MacBook-Pro-3 02.calendar % ./cal.js -y 10000 -m 10000
指定された年または月が無効です。(年:1900〜2100,月:1〜12が有効)
```

## ESlint実行
```
chiroru@MacBook-Pro-3 02.calendar % npx eslint cal.js
chiroru@MacBook-Pro-3 02.calendar % 
```

## Prettier実行
```
chiroru@MacBook-Pro-3 02.calendar % npx prettier --write cal.js
cal.js 80ms (unchanged)
```
