### PR TITLE
20240906 カレンダーのプログラム(JavaScript)

### DIFF
--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+
+import { Command } from "commander";
+import { DateTime } from "luxon";
+
+const program = new Command();
+
+program
+  .option("-y, --year <year>", "年を指定", parseInt)
+  .option("-m, --month <month>", "月を指定", parseInt)
+  .parse(process.argv);
+
+const options = program.opts();
+
+function printCalendar(year, month) {
+  if (
+    !year ||
+    !month ||
+    year < 1900 ||
+    year > 2100 ||
+    month < 1 ||
+    month > 12
+  ) {
+    process.stderr.write(
+      "指定された年または月が無効です。(年:1900〜2100,月:1〜12が有効)\n",
+    );
+    return;
+  }
+
+  const firstDay = DateTime.local(year, month, 1);
+  const lastDay = firstDay.endOf("month");
+
+  process.stdout.write(firstDay.toFormat("M月 yyyy").padStart(13) + "\n");
+  process.stdout.write("日 月 火 水 木 金 土\n");
+
+  let padding = " ".repeat((firstDay.weekday % 7) * 3);
+  process.stdout.write(padding);
+
+  for (let day = firstDay; day <= lastDay; day = day.plus({ days: 1 })) {
+    process.stdout.write(day.day.toString().padStart(2) + " ");
+    if (day.weekday === 6) {
+      process.stdout.write("\n");
+    }
+  }
+
+  if (lastDay.weekday !== 6) {
+    process.stdout.write("\n");
+  }
+}
+
+function main() {
+  const year = options.year || DateTime.now().year;
+  const month = options.month || DateTime.now().month;
+
+  try {
+    printCalendar(year, month);
+  } catch (error) {
+    process.stderr.write(
+      "無効な日付が指定されました。詳細: " + error.message + "\n",
+    );
+  }
+}
+
+main();

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -24,8 +24,8 @@ function printCalendar(year, month) {
   process.stdout.write(padding);
 
   for (let day = firstDay; day <= lastDay; day = day.plus({ days: 1 })) {
-    let marginBetweenDay = day.day < 10 ? 2 : 1;
-    let formattedDay = day.day.toString().padStart(marginBetweenDay);
+    const marginBetweenDay = day.day < 10 ? 2 : 1;
+    const formattedDay = day.day.toString().padStart(marginBetweenDay);
 
     if (day.weekday === 6 || day.hasSame(lastDay, "day")) {
       console.log(formattedDay);

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -5,8 +5,8 @@ import { DateTime } from "luxon";
 
 function printCalendar(year, month) {
   if (year < 1900 || year > 2100 || month < 1 || month > 12) {
-    process.stderr.write(
-      "指定された年または月が無効です。(年:1900〜2100,月:1〜12が有効)\n",
+    console.error(
+      "指定された年または月が無効です。(年:1900〜2100,月:1〜12が有効)",
     );
     return;
   }

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -11,13 +11,12 @@ function printCalendar(year, month) {
     process.exit(1);
   }
 
-  const headerYear = year.toString();
-  const headerMonth = `${month}月`;
-
-  console.log(`      ${headerMonth} ${headerYear}\n日 月 火 水 木 金 土`);
+  console.log(`      ${month}月 ${year.toString()}`);
+  console.log("日 月 火 水 木 金 土");
 
   const firstDay = DateTime.local(year, month, 1);
   const lastDay = firstDay.endOf("month");
+
   const padding = " ".repeat((firstDay.weekday % 7) * 3);
   process.stdout.write(padding);
 
@@ -26,13 +25,12 @@ function printCalendar(year, month) {
 
     if (day.weekday === 6 || day.hasSame(lastDay, "day")) {
       console.log(formattedDay);
+      if (day.hasSame(lastDay, "day") && lastDay.weekday !== 6) {
+        console.log();
+      }
     } else {
       process.stdout.write(`${formattedDay} `);
     }
-  }
-
-  if (lastDay.weekday !== 6) {
-    console.log();
   }
 }
 

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -11,14 +11,11 @@ function printCalendar(year, month) {
     process.exit(1);
   }
 
-  const marginAfterOctober = 9;
-  const marginBeforeOctober = 8;
   const headerYear = `${year}`;
-  const headerMonth = `${month}月`.padStart(
-    month.toString().length == 2 ? marginAfterOctober : marginBeforeOctober,
-  );
+  const headerMonth = month < 10 ? ` ${month}月` : `${month}月`;
+  const headerMargin = 8;
 
-  console.log(`${headerMonth} ${headerYear}`);
+  console.log(`${headerMonth.padStart(headerMargin)} ${headerYear}`);
   console.log("日 月 火 水 木 金 土");
 
   const firstDay = DateTime.local(year, month, 1);

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -13,9 +13,8 @@ function printCalendar(year, month) {
 
   const headerYear = year.toString();
   const headerMonth = `${month}月`;
-  const headerMargin = month >= 10 ? 9 : 8;
 
-  console.log(`${headerMonth.padStart(headerMargin)} ${headerYear}`);
+  console.log(`      ${headerMonth} ${headerYear}`);
   console.log("日 月 火 水 木 金 土");
 
   const firstDay = DateTime.local(year, month, 1);

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -37,9 +37,7 @@ function printCalendar(year, month) {
     }
   }
 
-  if (lastDay.weekday !== 6) {
-    console.log();
-  }
+  if (lastDay.weekday !== 6) console.log();
 }
 
 function main() {

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -52,13 +52,7 @@ function main() {
   const year = options.year || now.year;
   const month = options.month || now.month;
 
-  try {
-    printCalendar(year, month);
-  } catch (error) {
-    process.stderr.write(
-      "無効な日付が指定されました。詳細: " + error.message + "\n",
-    );
-  }
+  printCalendar(year, month);
 }
 
 main();

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -25,9 +25,11 @@ function printCalendar(year, month) {
   process.stdout.write(padding);
 
   for (let day = firstDay; day <= lastDay; day = day.plus({ days: 1 })) {
-    process.stdout.write(day.day.toString().padStart(2) + " ");
-    if (day.weekday === 6) {
-      process.stdout.write("\n");
+    const formattedDay = `${day.day.toString().padStart(2)} `;
+    if (day.weekday === 6 || lastDay.daysInMonth === day.day) {
+      console.log(formattedDay.slice(0, -1));
+    } else {
+      process.stdout.write(formattedDay);
     }
   }
 

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -15,6 +15,7 @@ function printCalendar(year, month) {
   const lastDay = firstDay.endOf("month");
   const marginAfterOctober = 9;
   const marginBeforeOctober = 8;
+  const marginBetweenDay = 2;
   const headerYear = `${year}`;
   const headerMonth = `${month}月`.padStart(
     month.toString().length == 2 ? marginAfterOctober : marginBeforeOctober,
@@ -27,11 +28,12 @@ function printCalendar(year, month) {
   process.stdout.write(padding);
 
   for (let day = firstDay; day <= lastDay; day = day.plus({ days: 1 })) {
-    const formattedDay = `${day.day.toString().padStart(2)} `;
-    if (day.weekday === 6 || lastDay.daysInMonth === day.day) {
-      console.log(formattedDay.slice(0, -1));
+    let formattedDay = `${day.day.toString().padStart(marginBetweenDay)}`;
+
+    if (day.weekday === 6 || day.hasSame(lastDay, "day")) {
+      console.log(formattedDay);
     } else {
-      process.stdout.write(formattedDay);
+      process.stdout.write(`${formattedDay} `);
     }
   }
 

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -21,7 +21,7 @@ function printCalendar(year, month) {
   }
   console.log("日 月 火 水 木 金 土");
 
-  let padding = " ".repeat((firstDay.weekday % 7) * 3);
+  const padding = " ".repeat((firstDay.weekday % 7) * 3);
   process.stdout.write(padding);
 
   for (let day = firstDay; day <= lastDay; day = day.plus({ days: 1 })) {

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -11,7 +11,7 @@ function printCalendar(year, month) {
     process.exit(1);
   }
 
-  const headerYear = `${year}`;
+  const headerYear = year.toString();
   const headerMonth = month < 10 ? ` ${month}月` : `${month}月`;
   const headerMargin = 8;
 

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -11,7 +11,7 @@ function printCalendar(year, month) {
     process.exit(1);
   }
 
-  console.log(`      ${month}月 ${year.toString()}`);
+  console.log(`      ${month}月 ${year}`);
   console.log("日 月 火 水 木 金 土");
 
   const firstDay = DateTime.local(year, month, 1);

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -22,12 +22,12 @@ function printCalendar(year, month) {
 
   for (let day = firstDay; day <= lastDay; day = day.plus({ days: 1 })) {
     const formattedDay = day.day.toString().padStart(2);
-
-    if (day.weekday === 6 || day.hasSame(lastDay, "day")) {
+    const isLastDay = day.hasSame(lastDay, "day");
+    if (isLastDay && lastDay.weekday !== 6) {
       console.log(formattedDay);
-      if (day.hasSame(lastDay, "day") && lastDay.weekday !== 6) {
-        console.log();
-      }
+      console.log();
+    } else if (isLastDay || day.weekday === 6) {
+      console.log(formattedDay);
     } else {
       process.stdout.write(`${formattedDay} `);
     }

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -14,7 +14,11 @@ function printCalendar(year, month) {
   const firstDay = DateTime.local(year, month, 1);
   const lastDay = firstDay.endOf("month");
 
-  console.log(firstDay.toFormat("M月 yyyy").padStart(13));
+  if (month.toString().length == 2) {
+    console.log(firstDay.toFormat("M月 yyyy").padStart(14));
+  } else {
+    console.log(firstDay.toFormat("M月 yyyy").padStart(13));
+  }
   console.log("日 月 火 水 木 金 土");
 
   let padding = " ".repeat((firstDay.weekday % 7) * 3);

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -14,8 +14,7 @@ function printCalendar(year, month) {
   const headerYear = year.toString();
   const headerMonth = `${month}月`;
 
-  console.log(`      ${headerMonth} ${headerYear}`);
-  console.log("日 月 火 水 木 金 土");
+  console.log(`      ${headerMonth} ${headerYear}\n日 月 火 水 木 金 土`);
 
   const firstDay = DateTime.local(year, month, 1);
   const lastDay = firstDay.endOf("month");

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -23,10 +23,11 @@ function printCalendar(year, month) {
   for (let day = firstDay; day <= lastDay; day = day.plus({ days: 1 })) {
     const formattedDay = day.day.toString().padStart(2);
     const isLastDay = day.hasSame(lastDay, "day");
+    const isSaturday = day.weekday === 6;
     if (isLastDay) {
       console.log(formattedDay);
       console.log();
-    } else if (day.weekday === 6) {
+    } else if (isSaturday) {
       console.log(formattedDay);
     } else {
       process.stdout.write(`${formattedDay} `);

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -48,8 +48,8 @@ function main() {
 
   const options = program.opts();
   const now = DateTime.now();
-  const year = options.year || now.year;
-  const month = options.month || now.month;
+  const year = options.year ?? now.year;
+  const month = options.month ?? now.month;
 
   printCalendar(year, month);
 }

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -13,12 +13,14 @@ function printCalendar(year, month) {
 
   const firstDay = DateTime.local(year, month, 1);
   const lastDay = firstDay.endOf("month");
+  const marginAfterOctober = 9;
+  const marginBeforeOctober = 8;
+  const headerYear = `${year}`;
+  const headerMonth = `${month}月`.padStart(
+    month.toString().length == 2 ? marginAfterOctober : marginBeforeOctober,
+  );
 
-  if (month.toString().length == 2) {
-    console.log(firstDay.toFormat("M月 yyyy").padStart(14));
-  } else {
-    console.log(firstDay.toFormat("M月 yyyy").padStart(13));
-  }
+  console.log(`${headerMonth} ${headerYear}`);
   console.log("日 月 火 水 木 金 土");
 
   const padding = " ".repeat((firstDay.weekday % 7) * 3);

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -48,8 +48,9 @@ function main() {
     .parse(process.argv);
 
   const options = program.opts();
-  const year = options.year || DateTime.now().year;
-  const month = options.month || DateTime.now().month;
+  const now = DateTime.now();
+  const year = options.year || now.year;
+  const month = options.month || now.month;
 
   try {
     printCalendar(year, month);

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -24,8 +24,8 @@ function printCalendar(year, month) {
   process.stdout.write(padding);
 
   for (let day = firstDay; day <= lastDay; day = day.plus({ days: 1 })) {
-    const marginBetweenDay = day.day < 10 ? 2 : 1;
-    const formattedDay = day.day.toString().padStart(marginBetweenDay);
+    const padStartBetweenDay = 2;
+    const formattedDay = day.day.toString().padStart(padStartBetweenDay);
 
     if (day.weekday === 6 || day.hasSame(lastDay, "day")) {
       console.log(formattedDay);

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -11,11 +11,8 @@ function printCalendar(year, month) {
     process.exit(1);
   }
 
-  const firstDay = DateTime.local(year, month, 1);
-  const lastDay = firstDay.endOf("month");
   const marginAfterOctober = 9;
   const marginBeforeOctober = 8;
-  const marginBetweenDay = 2;
   const headerYear = `${year}`;
   const headerMonth = `${month}月`.padStart(
     month.toString().length == 2 ? marginAfterOctober : marginBeforeOctober,
@@ -24,10 +21,14 @@ function printCalendar(year, month) {
   console.log(`${headerMonth} ${headerYear}`);
   console.log("日 月 火 水 木 金 土");
 
+  const firstDay = DateTime.local(year, month, 1);
   const padding = " ".repeat((firstDay.weekday % 7) * 3);
   process.stdout.write(padding);
 
+  const lastDay = firstDay.endOf("month");
+
   for (let day = firstDay; day <= lastDay; day = day.plus({ days: 1 })) {
+    let marginBetweenDay = day.day < 10 ? 2 : 1;
     let formattedDay = day.day.toString().padStart(marginBetweenDay);
 
     if (day.weekday === 6 || day.hasSame(lastDay, "day")) {

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -4,14 +4,7 @@ import { Command } from "commander";
 import { DateTime } from "luxon";
 
 function printCalendar(year, month) {
-  if (
-    !year ||
-    !month ||
-    year < 1900 ||
-    year > 2100 ||
-    month < 1 ||
-    month > 12
-  ) {
+  if (year < 1900 || year > 2100 || month < 1 || month > 12) {
     process.stderr.write(
       "指定された年または月が無効です。(年:1900〜2100,月:1〜12が有効)\n",
     );

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -22,8 +22,7 @@ function printCalendar(year, month) {
   process.stdout.write(padding);
 
   for (let day = firstDay; day <= lastDay; day = day.plus({ days: 1 })) {
-    const padStartBetweenDay = 2;
-    const formattedDay = day.day.toString().padStart(padStartBetweenDay);
+    const formattedDay = day.day.toString().padStart(2);
 
     if (day.weekday === 6 || day.hasSame(lastDay, "day")) {
       console.log(formattedDay);

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -8,7 +8,7 @@ function printCalendar(year, month) {
     console.error(
       "指定された年または月が無効です。(年:1900〜2100,月:1〜12が有効)",
     );
-    return;
+    process.exit(1);
   }
 
   const firstDay = DateTime.local(year, month, 1);

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -12,8 +12,8 @@ function printCalendar(year, month) {
   }
 
   const headerYear = year.toString();
-  const headerMonth = month < 10 ? ` ${month}月` : `${month}月`;
-  const headerMargin = 8;
+  const headerMonth = `${month}月`;
+  const headerMargin = month >= 10 ? 9 : 8;
 
   console.log(`${headerMonth.padStart(headerMargin)} ${headerYear}`);
   console.log("日 月 火 水 木 金 土");

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -14,8 +14,8 @@ function printCalendar(year, month) {
   const firstDay = DateTime.local(year, month, 1);
   const lastDay = firstDay.endOf("month");
 
-  process.stdout.write(firstDay.toFormat("M月 yyyy").padStart(13) + "\n");
-  process.stdout.write("日 月 火 水 木 金 土\n");
+  console.log(firstDay.toFormat("M月 yyyy").padStart(13));
+  console.log("日 月 火 水 木 金 土");
 
   let padding = " ".repeat((firstDay.weekday % 7) * 3);
   process.stdout.write(padding);

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -23,10 +23,10 @@ function printCalendar(year, month) {
   for (let day = firstDay; day <= lastDay; day = day.plus({ days: 1 })) {
     const formattedDay = day.day.toString().padStart(2);
     const isLastDay = day.hasSame(lastDay, "day");
-    if (isLastDay && lastDay.weekday !== 6) {
+    if (isLastDay) {
       console.log(formattedDay);
       console.log();
-    } else if (isLastDay || day.weekday === 6) {
+    } else if (day.weekday === 6) {
       console.log(formattedDay);
     } else {
       process.stdout.write(`${formattedDay} `);

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -3,15 +3,6 @@
 import { Command } from "commander";
 import { DateTime } from "luxon";
 
-const program = new Command();
-
-program
-  .option("-y, --year <year>", "年を指定", parseInt)
-  .option("-m, --month <month>", "月を指定", parseInt)
-  .parse(process.argv);
-
-const options = program.opts();
-
 function printCalendar(year, month) {
   if (
     !year ||
@@ -49,6 +40,14 @@ function printCalendar(year, month) {
 }
 
 function main() {
+  const program = new Command();
+
+  program
+    .option("-y, --year <year>", "年を指定", parseInt)
+    .option("-m, --month <month>", "月を指定", parseInt)
+    .parse(process.argv);
+
+  const options = program.opts();
   const year = options.year || DateTime.now().year;
   const month = options.month || DateTime.now().month;
 

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -34,7 +34,7 @@ function printCalendar(year, month) {
   }
 
   if (lastDay.weekday !== 6) {
-    process.stdout.write("\n");
+    console.log();
   }
 }
 

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -28,7 +28,7 @@ function printCalendar(year, month) {
   process.stdout.write(padding);
 
   for (let day = firstDay; day <= lastDay; day = day.plus({ days: 1 })) {
-    let formattedDay = `${day.day.toString().padStart(marginBetweenDay)}`;
+    let formattedDay = day.day.toString().padStart(marginBetweenDay);
 
     if (day.weekday === 6 || day.hasSame(lastDay, "day")) {
       console.log(formattedDay);

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -37,7 +37,9 @@ function printCalendar(year, month) {
     }
   }
 
-  if (lastDay.weekday !== 6) console.log();
+  if (lastDay.weekday !== 6) {
+    console.log();
+  }
 }
 
 function main() {

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -19,10 +19,9 @@ function printCalendar(year, month) {
   console.log("日 月 火 水 木 金 土");
 
   const firstDay = DateTime.local(year, month, 1);
+  const lastDay = firstDay.endOf("month");
   const padding = " ".repeat((firstDay.weekday % 7) * 3);
   process.stdout.write(padding);
-
-  const lastDay = firstDay.endOf("month");
 
   for (let day = firstDay; day <= lastDay; day = day.plus({ days: 1 })) {
     let marginBetweenDay = day.day < 10 ? 2 : 1;

--- a/02.calendar/package-lock.json
+++ b/02.calendar/package-lock.json
@@ -4,6 +4,10 @@
   "requires": true,
   "packages": {
     "": {
+      "dependencies": {
+        "commander": "^9.0.0",
+        "luxon": "^3.0.0"
+      },
       "devDependencies": {
         "@eslint/js": "^9.9.0",
         "eslint": "^9.9.0",
@@ -298,6 +302,15 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -785,6 +798,15 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/luxon": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.5.0.tgz",
+      "integrity": "sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/minimatch": {
       "version": "3.1.2",

--- a/02.calendar/package-lock.json
+++ b/02.calendar/package-lock.json
@@ -5,8 +5,8 @@
   "packages": {
     "": {
       "dependencies": {
-        "commander": "^9.0.0",
-        "luxon": "^3.0.0"
+        "commander": "^12.1.0",
+        "luxon": "^3.5.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.9.0",
@@ -304,12 +304,11 @@
       "dev": true
     },
     "node_modules/commander": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
-      "license": "MIT",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "engines": {
-        "node": "^12.20.0 || >=14"
+        "node": ">=18"
       }
     },
     "node_modules/concat-map": {

--- a/02.calendar/package.json
+++ b/02.calendar/package.json
@@ -4,8 +4,8 @@
     "lint": "prettier --check . && eslint ."
   },
   "dependencies": {
-    "commander": "^9.0.0",
-    "luxon": "^3.0.0"
+    "commander": "^12.1.0",
+    "luxon": "^3.5.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",

--- a/02.calendar/package.json
+++ b/02.calendar/package.json
@@ -3,6 +3,10 @@
     "fix": "prettier --write . && eslint --fix .",
     "lint": "prettier --check . && eslint ."
   },
+  "dependencies": {
+    "commander": "^9.0.0",
+    "luxon": "^3.0.0"
+  },
   "devDependencies": {
     "@eslint/js": "^9.9.0",
     "eslint": "^9.9.0",


### PR DESCRIPTION
## プラクティス
[カレンダーのプログラム(JavaScript)](https://bootcamp.fjord.jp/practices/196)

## 使用ライブラリ
[Luxon(github)](https://github.com/moment/luxon)
[commander(github)](https://github.com/tj/commander.js)

## 既存のcalコマンド
```
chiroru@MacBook-Pro-4 02.calendar % cal
      9月 2024         
日 月 火 水 木 金 土  
 1  2  3  4  5  6  7
 8  9 10 11 12 13 14
15 16 17 18 19 20 21
22 23 24 25 26 27 28
29 30
```

## 実装したプログラムの実行結果
```
chiroru@MacBook-Pro-4 02.calendar % ./cal.js                     
      9月 2024
日 月 火 水 木 金 土
 1  2  3  4  5  6  7
 8  9 10 11 12 13 14
15 16 17 18 19 20 21
22 23 24 25 26 27 28
29 30
```

## オプション指定
オプションの有効値(年:1900〜2100,月:1〜12)
```
chiroru@MacBook-Pro-4 02.calendar % ./cal.js -y 2030 -m 12
      12月 2030
日 月 火 水 木 金 土
 1  2  3  4  5  6  7
 8  9 10 11 12 13 14
15 16 17 18 19 20 21
22 23 24 25 26 27 28
29 30 31
```

## 無効なオプションが設定された場合
以下のようなエラーメッセージが出力されるように。
```
chiroru@MacBook-Pro-4 02.calendar % ./cal.js -y 10000 -m 10000
指定された年または月が無効です。(年:1900〜2100,月:1〜12が有効)
```

## ESLint実行
<img width="836" alt="image" src="https://github.com/user-attachments/assets/5c687d19-4ee8-4ec9-9083-58b54c891b8e">

## Prettier実行
<img width="858" alt="image" src="https://github.com/user-attachments/assets/b0e133be-52a8-4717-9f38-799cbfa4ce95">

# 使用方法

## ローカル環境にクローンする
```
git clone git@github.com:taichihub/js-practices.git
```

## 当ブランチに移動
```
git checkout 02-my-calendar
```

## パッケージインストール
```
npm install
```

## 実行
```
./cal.js
```